### PR TITLE
linkify: do not autolink trailing punctuation

### DIFF
--- a/util.py
+++ b/util.py
@@ -190,6 +190,7 @@ _LINK_RE = re.compile(ur'\bhttps?://[^\s<>]+\b')
 # more complicated alternative:
 # http://stackoverflow.com/questions/720113#comment23297770_2102648
 
+
 def extract_links(text):
   """Returns a list of unique string URLs in the given text.
 
@@ -214,6 +215,7 @@ _LINKIFY_RE = re.compile(r"""
   ([/?][\w/.\-_~.;:%?@$#&()=+]*)?   # path and query
   """, re.VERBOSE | re.UNICODE)
 
+
 def linkify(text, pretty=False, **kwargs):
   """Adds HTML links to URLs in the given plain text.
 
@@ -229,14 +231,24 @@ def linkify(text, pretty=False, **kwargs):
 
   Returns: string, linkified input
   """
+  def split_trailing_punc(text):
+    # split trailing punctuation off the end of a url
+    ii = len(text) - 1
+    while (ii >= 0 and text[ii] in '.!?,;:)'
+           # allow 1 () pair
+           and (text[ii] != ')' or '(' not in text)):
+        ii -= 1
+    return text[:ii + 1], text[ii + 1:]
+
   def make_link(m):
-    url = href = m.group(0)
+    head, tail = split_trailing_punc(m.group(0))
+    url = href = head
     if href.startswith('www.'):
       href = 'http://' + href
     if pretty:
-      return pretty_link(href, **kwargs)
+      return pretty_link(href, **kwargs) + tail
     else:
-      return u'<a href="%s">%s</a>' % (href, url)
+      return u'<a href="%s">%s</a>%s' % (href, url, tail)
 
   return _LINKIFY_RE.sub(make_link, text)
 

--- a/util.py
+++ b/util.py
@@ -148,8 +148,9 @@ def domain_from_link(url):
     parsed = urlparse.urlparse('http://' + url)
 
   domain = parsed.netloc
-  if domain.startswith('www.'):
-    domain = domain[4:]
+  for subdomain in ('www.', 'mobile.', 'm.'):
+    if domain.startswith(subdomain):
+      domain = domain[len(subdomain):]
   if domain and HOSTNAME_RE.match(domain):
     return domain
 

--- a/util_test.py
+++ b/util_test.py
@@ -211,7 +211,12 @@ class UtilTest(testutil.HandlerTest):
          u'http://aÇb'),
         # https://github.com/snarfed/bridgy/issues/325#issuecomment-67923098
         ('<a href="https://github.com/pfefferle/wordpress-indieweb-press-this">https://github.com/pfefferle/wordpress-indieweb-press-this</a> >',
-         'https://github.com/pfefferle/wordpress-indieweb-press-this >')):
+         'https://github.com/pfefferle/wordpress-indieweb-press-this >'),
+        ('interesting how twitter auto-links it <a href="http://example.com/a_link_(with_parens)">http://example.com/a_link_(with_parens)</a> vs. (<a href="http://example.com/a_link_without">http://example.com/a_link_without</a>)',
+         'interesting how twitter auto-links it http://example.com/a_link_(with_parens) vs. (http://example.com/a_link_without)'),
+        ('links separated by punctuation <a href="http://foo.com">http://foo.com</a>, <a href="http://bar.com/">http://bar.com/</a>; <a href="http://baz.com/?s=query">http://baz.com/?s=query</a>; did it work?',
+         'links separated by punctuation http://foo.com, http://bar.com/; http://baz.com/?s=query; did it work?'),
+    ):
         self.assertEqual(expected, util.linkify(input))
 
   def test_pretty_link(self):


### PR DESCRIPTION
based loosely on CASSIS, allow regex to match valid punctuation
characters greedily, then trim it off the end of the URL. allow
)'s if there is an ( anywhere in the body of the URL.

also adds a change to domain_from_link that I suspect you already 
made on your end but haven't checked in yet.
