### PR TITLE
Bugfix/ravenscroftj/user agent

### DIFF
--- a/util.py
+++ b/util.py
@@ -36,7 +36,7 @@ except ImportError:
   ujson = None
   import json
 
-USER_AGENT = 'webutil (https://github.com/snarfed/webutil/)'
+USER_AGENT = 'oauth-dropins (https://oauth-dropins.appspot.com/)'
 
 # These are used in interpret_http_exception() and is_connection_failure(). They
 # use dependencies that we may or may not have, so degrade gracefully if they're

--- a/util.py
+++ b/util.py
@@ -36,6 +36,8 @@ except ImportError:
   ujson = None
   import json
 
+USER_AGENT = 'webutil (https://github.com/snarfed/webutil/)'
+
 # These are used in interpret_http_exception() and is_connection_failure(). They
 # use dependencies that we may or may not have, so degrade gracefully if they're
 # not available.
@@ -106,6 +108,7 @@ try:
   import tweepy
 except ImportError:
   tweepy = None
+
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 EPOCH_ISO = EPOCH.isoformat()
@@ -1539,6 +1542,12 @@ def requests_fn(fn):
     kwargs.setdefault('timeout', HTTP_TIMEOUT)
     # stream to short circuit on too-long response bodies (below)
     kwargs.setdefault('stream', True)
+
+    if kwargs.get('headers') is None:
+      kwargs['headers'] =  {}
+
+    if ('user-agent' not in[key.lower() for key in kwargs.get('headers',{}).keys()]):
+      kwargs['headers']['User-Agent'] = USER_AGENT
 
     try:
       # use getattr so that stubbing out with mox still works


### PR DESCRIPTION
As per the issue I opened a couple of weeks back I have updated webutil so that whenever it uses requests it sets a default user agent string. I've modified test utils and some of the silo-specific granary tests to be able to deal with this new behaviour.

I initially went with a webutil user agent but since this library is maintained as part of oauth-dropins I decided that the oauth-dropins user agent string was probably more appropriate.

Link to original issue I opened with bridgy [here](https://github.com/snarfed/bridgy/issues/1099)