### PR TITLE
Make update_scheme only upgrade http->https

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -247,12 +247,14 @@ class UtilTest(testutil.TestCase):
                           repr((input, domains, expected)))
 
   def test_update_scheme(self):
+    # Should only upgrade http -> https, never downgrade
     with Flask(__name__).test_request_context('/'):
+      request.scheme = 'http'
       for orig in 'http', 'https':
-        for new in 'http', 'https':
-          request.scheme = new
-          updated = util.update_scheme(orig + '://foo', request)
-          self.assertEqual(new + '://foo', updated)
+        self.assertEqual(orig + "://foo", util.update_scheme(orig + "://foo", request))
+      request.scheme = 'https'
+      for orig in 'http', 'https':
+        self.assertEqual("https://foo", util.update_scheme(orig + "://foo", request))
 
   def test_schemeless(self):
     for expected, url in (

--- a/util.py
+++ b/util.py
@@ -490,7 +490,9 @@ def update_scheme(url, request):
 
   Returns: string, url
   """
-  return urllib.parse.urlunparse((request.scheme,) + urlparse(url)[1:])
+  if request.scheme == 'https':
+    return urllib.parse.urlunparse((request.scheme,) + urlparse(url)[1:])
+  return url
 
 
 def schemeless(url, slashes=True):

--- a/util.py
+++ b/util.py
@@ -479,7 +479,8 @@ def domain_or_parent_in(input, domains):
 
 
 def update_scheme(url, request):
-  """Returns a modified URL with the current request's scheme.
+  """Returns a modified URL with the scheme upgraded to https if the
+  request uses https.
 
   Useful for converting URLs to https if and only if the current request itself
   is being served over https.


### PR DESCRIPTION
As described - `update_scheme` should never downgrade HTTPS to HTTP, only the other way around!